### PR TITLE
preserve lonely text nodes as well

### DIFF
--- a/src/format-preserver/format-preserver.js
+++ b/src/format-preserver/format-preserver.js
@@ -67,6 +67,26 @@ module.exports = (function() {
     return [].slice.call(el.children);
   };
 
+  var getHtml = function(element) {
+    var html = [];
+    var list = [].slice.call(element);
+    for (var k in list) {
+      var node = list[k];
+      switch (node.nodeType) {
+        case 1: // regular element nodes
+          html.push(node.innerHTML);
+          break;
+        case 3: // text nodes
+          html.push(node.nodeValue);
+          break;
+        default:
+
+      }
+    }
+
+    return html.join('');
+  };
+
   var addMarkers = function(element) {
     var children = getChildren(element);
 
@@ -85,20 +105,7 @@ module.exports = (function() {
       }
     }
 
-    var html = [];
-    var list = [].slice.call(element);
-    for (var k in list) {
-      var node = list[k];
-      switch(node.nodeType){
-        case 1: // regular element nodes
-          html.push(node.innerHTML);
-          break;
-        case 3: // text nodes
-          html.push(node.nodeValue);
-      }
-    }
-
-    return html.join('');
+    return getHtml(element);
   };
 
   var replaceMaker = function(element) {

--- a/src/format-preserver/format-preserver.js
+++ b/src/format-preserver/format-preserver.js
@@ -73,10 +73,10 @@ module.exports = (function() {
     for (var k in list) {
       var node = list[k];
       switch (node.nodeType) {
-        case 1: // regular element nodes
+        case Node.ELEMENT_NODE:
           html.push(node.innerHTML);
           break;
-        case 3: // text nodes
+        case Node.TEXT_NODE:
           html.push(node.nodeValue);
           break;
         default:
@@ -99,7 +99,7 @@ module.exports = (function() {
       var list = [].slice.call(element);
       for (var k in list) {
         var listItem = list[k];
-        if (listItem.nodeType === 1 && styleMarker.test(listItem)) {
+        if (listItem.nodeType === Node.ELEMENT_NODE && styleMarker.test(listItem)) {
           addMarker(listItem, styleMarker);
         }
       }

--- a/src/format-preserver/format-preserver.js
+++ b/src/format-preserver/format-preserver.js
@@ -69,6 +69,7 @@ module.exports = (function() {
 
   var addMarkers = function(element) {
     var children = getChildren(element);
+
     if (children.length) {
       addMarkers(children);
     }
@@ -77,9 +78,9 @@ module.exports = (function() {
       var styleMarker = marker[o];
       var list = [].slice.call(element);
       for (var k in list) {
-        var el = list[k];
-        if (styleMarker.test(el)) {
-          addMarker(el, styleMarker);
+        var listItem = list[k];
+        if (listItem.nodeType === 1 && styleMarker.test(listItem)) {
+          addMarker(listItem, styleMarker);
         }
       }
     }
@@ -87,7 +88,14 @@ module.exports = (function() {
     var html = [];
     var list = [].slice.call(element);
     for (var k in list) {
-      html.push(list[k].innerHTML);
+      var node = list[k];
+      switch(node.nodeType){
+        case 1: // regular element nodes
+          html.push(node.innerHTML);
+          break;
+        case 3: // text nodes
+          html.push(node.nodeValue);
+      }
     }
 
     return html.join('');
@@ -107,13 +115,9 @@ module.exports = (function() {
 
   var parseHtml = function(html) {
     var tmpDocument = document.implementation.createHTMLDocument('parser');
-    tmpDocument.body.innerHTML = [
-      '<head></head>',
-      html,
-      '<body></body>'
-    ].join('');
+    tmpDocument.body.innerHTML = html;
 
-    return tmpDocument.body.children;
+    return tmpDocument.body.childNodes;
   };
 
   return {

--- a/src/format-preserver/format-preserver_spec.js
+++ b/src/format-preserver/format-preserver_spec.js
@@ -7,11 +7,13 @@ describe('Format Preserver', function() {
     describe('using inline styles', function() {
       it('should strip html and styles but preserve bold, italics, underline as inline style', function() {
         var pasteContent = [
+          'Text should not be removed',
           '<div style="font-weight: bold">inner</div>',
           '<p style="text-decoration: underline">inner</p>',
           '<span style="font-style: italic">inner</span>'
         ].join('');
         var expected = [
+          'Text should not be removed',
           '<span style="font-weight: bold">inner</span>',
           '<span style="text-decoration: underline">inner</span>',
           '<span style="font-style: italic">inner</span>'
@@ -71,13 +73,16 @@ describe('Format Preserver', function() {
     describe('using inline styles', function() {
       it('should strip html and styles but preserve bold, italics, underline', function() {
         var pasteContent = [
+          'Text should not ',
           '<div>',
+          'be removed',
           '<span style="font-weight: bold">inner</span>',
           '<span style="text-decoration: underline">inner</span>',
           '<span style="font-style: italic">inner</span>',
           '</div>'
         ].join('');
         var expected = [
+          'Text should not be removed',
           '<span style="font-weight: bold">inner</span>',
           '<span style="text-decoration: underline">inner</span>',
           '<span style="font-style: italic">inner</span>'


### PR DESCRIPTION
when textnodes were not enclosed by an element
they were removed. This is fixed now due using childNodes
instead of children.

for https://github.com/easybib/issues/issues/4698